### PR TITLE
Update flatpak runtime & base version to 24.08

### DIFF
--- a/com.microsoft.EdgeDev.yaml
+++ b/com.microsoft.EdgeDev.yaml
@@ -1,9 +1,9 @@
 app-id: com.microsoft.EdgeDev
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '24.08'
 command: edge
 separate-locales: false
 build-options:


### PR DESCRIPTION
Update runtime and base version to 24.08. Current version 22.08 is EOL and no longer receives updates. This is also the version used by edge stable at com.microsoft.Edge